### PR TITLE
Output job name only after it has been formatted with new member id

### DIFF
--- a/engine/run_ensemble.py
+++ b/engine/run_ensemble.py
@@ -213,10 +213,10 @@ def run_ensemble(
         )
 
         if not dry:
-            logger.info("running the model with '{}'".format(" ".join(job)))
             job = submit_command.split() + [
                 perturbed_run_script_name.format(member_id=m_id)
             ]
+            logger.info("running the model with '{}'".format(" ".join(job)))
             append_job(job, job_list, parallel)
 
     finalize_jobs(job_list, dry, parallel)


### PR DESCRIPTION
This PR fixes an (aesthetic) issue with the output of the _run-ensemble_ command. The code outputs the sbatch command it will use for running a specific ensemble, however the name of the runscript is wrong. In more detail, the name of the runscript corresponds to the one of previous member, i.e. the numbers are shifted by 1. Note that this is only an output problem.

This PR simply moves the output of the "sbatch command" string to after the `job` variable is formatted with the correct member id.