### PR TITLE
Extend for 1mom-microphysics granule

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,10 @@
+| Author name             | Affiliation                                         |
+| ----------------------- | --------------------------------------------------- |
+| Remo Dietlicher         | C2SM                                                |
+| Fabian Gessler          | C2SM                                                |
+| Daniel Hupp             | MeteoSwiss                                          |
+| Marek Jacob             | DWD                                                 |
+| Annika Lauber           | C2SM                                                |
+| Giacomo Serafini        | MeteoSwiss                                          |
+| Mikael Stellio          | C2SM                                                |
+| Ben Weber               | MeteoSwiss                                          |

--- a/engine/run_ensemble.py
+++ b/engine/run_ensemble.py
@@ -73,16 +73,17 @@ def prepare_perturbed_run_script(
     rhs_old = [None if r == "None" else r for r in rhs_old]
 
     for line in in_file:
+        out_line = line
         # replace input directory with the ones given in config file
-        for lh, rh_old, rh_new in zip(lhs, rhs_old, rhs_new):
-            out_line = replace_assignment(line, lh, rh_new, rh_old, seed)
-            # replace first match
-            if out_line != line:
-                break
+        #for lh, rh_old, rh_new in zip(lhs, rhs_old, rhs_new):
+        #    out_line = replace_assignment(line, lh, rh_new, rh_old, seed)
+        #    # replace first match
+        #    if out_line != line:
+        #        break
 
-        # rename the experiment name
-        if line == out_line:
-            out_line = replace_string(line, experiment_name, modified_experiment_name)
+        ## rename the experiment name
+        #if line == out_line:
+        #    out_line = replace_string(line, experiment_name, modified_experiment_name)
 
         out_file.write(out_line)
 
@@ -216,17 +217,17 @@ def run_ensemble(
         append_job(job, job_list, parallel)
 
     # run the ensemble
-    Path(perturbed_run_dir).mkdir(exist_ok=True, parents=True)
-    os.chdir(perturbed_run_dir)
     if len(member_num) == 1:
         member_num = [i for i in range(1, member_num[0] + 1)]
     for m_num in member_num:
         m_id = str(m_num)
+        Path(perturbed_run_dir.format(member_id=m_id)).mkdir(exist_ok=True, parents=True)
+        os.chdir(perturbed_run_dir.format(member_id=m_id))
         if member_type:
             m_id = member_type + "_" + m_id
         runscript = "{}/{}".format(run_dir, run_script_name)
         perturbed_runscript = "{}/{}".format(
-            perturbed_run_dir, perturbed_run_script_name.format(member_id=m_id)
+            perturbed_run_dir.format(member_id=m_id), perturbed_run_script_name.format(member_id=m_id)
         )
 
         prepare_perturbed_run_script(
@@ -242,7 +243,7 @@ def run_ensemble(
 
         if not dry:
             job = submit_command.split() + [
-                perturbed_run_script_name.format(member_id=m_id)
+                perturbed_runscript
             ]
             logger.info("running the model with '{}'".format(" ".join(job)))
             append_job(job, job_list, parallel)

--- a/engine/run_ensemble.py
+++ b/engine/run_ensemble.py
@@ -73,7 +73,9 @@ def prepare_perturbed_run_script(
     rhs_old = [None if r == "None" else r for r in rhs_old]
 
     # only modify namelist if lhs,rhs_old or rhs_new are not equal None
-    if any(any(item is not None for item in entry) for entry in [lhs, rhs_old, rhs_new]):
+    if any(
+        any(item is not None for item in entry) for entry in [lhs, rhs_old, rhs_new]
+    ):
         for line in in_file:
             out_line = line
             # replace input directory with the ones given in config file

--- a/engine/run_ensemble.py
+++ b/engine/run_ensemble.py
@@ -74,16 +74,18 @@ def prepare_perturbed_run_script(
 
     for line in in_file:
         out_line = line
-        # replace input directory with the ones given in config file
-        #for lh, rh_old, rh_new in zip(lhs, rhs_old, rhs_new):
-        #    out_line = replace_assignment(line, lh, rh_new, rh_old, seed)
-        #    # replace first match
-        #    if out_line != line:
-        #        break
+        # only modify namelist if lhs,rhs_old or rhs_new are not equal None
+        if not all(all(item is None for item in entry) for entry in [lhs,rhs_old,rhs_new]):
+            #replace input directory with the ones given in config file
+            for lh, rh_old, rh_new in zip(lhs, rhs_old, rhs_new):
+                out_line = replace_assignment(line, lh, rh_new, rh_old, seed)
+                # replace first match
+                if out_line != line:
+                    break
 
-        ## rename the experiment name
-        #if line == out_line:
-        #    out_line = replace_string(line, experiment_name, modified_experiment_name)
+            # rename the experiment name
+            if line == out_line:
+                out_line = replace_string(line, experiment_name, modified_experiment_name)
 
         out_file.write(out_line)
 

--- a/engine/run_ensemble.py
+++ b/engine/run_ensemble.py
@@ -72,12 +72,10 @@ def prepare_perturbed_run_script(
         rhs_old = [None] * len(rhs_new)
     rhs_old = [None if r == "None" else r for r in rhs_old]
 
-    for line in in_file:
-        out_line = line
-        # only modify namelist if lhs,rhs_old or rhs_new are not equal None
-        if not all(
-            all(item is None for item in entry) for entry in [lhs, rhs_old, rhs_new]
-        ):
+    # only modify namelist if lhs,rhs_old or rhs_new are not equal None
+    if any(any(item is not None for item in entry) for entry in [lhs, rhs_old, rhs_new]):
+        for line in in_file:
+            out_line = line
             # replace input directory with the ones given in config file
             for lh, rh_old, rh_new in zip(lhs, rhs_old, rhs_new):
                 out_line = replace_assignment(line, lh, rh_new, rh_old, seed)
@@ -91,7 +89,9 @@ def prepare_perturbed_run_script(
                     line, experiment_name, modified_experiment_name
                 )
 
-        out_file.write(out_line)
+            out_file.write(out_line)
+    else:
+        out_file.write(in_file.read())
 
     logger.info("writing model run script to: {}".format(perturbed_runscript))
     out_file.close()

--- a/templates/granule.jinja
+++ b/templates/granule.jinja
@@ -17,7 +17,7 @@
         "perturb_amplitude": 1e-14,
         "variable_names": ["ta", "clw"],
         "copy_all_files": false,
-        "files": ["aes-new-gr_moderate-dt30s_atm_3d_ml_20080801T000000Z.nc"],
+        "files": ["input-data.nc"],
         "model_input_dir": "{{codebase_install}}",
         "perturbed_model_input_dir": "{{reference}}/perturb/{{experiment_name}}_member_id_{member_id}"
     },

--- a/templates/granule.jinja
+++ b/templates/granule.jinja
@@ -9,7 +9,7 @@
         "member_num": "[{member_num}]",
         "member_type": "{{member_type}}",
         "file_specification": [{
-            "NetCDF": { "format": "netcdf", "time_dim": null, "horizontal_dims": "ncells" }
+            "NetCDF": { "format": "netcdf", "time_dim": null, "horizontal_dims": ["ncells"]  }
         }],
         "savedir": "{{reference}}/plots"
     },

--- a/templates/granule.jinja
+++ b/templates/granule.jinja
@@ -1,0 +1,44 @@
+{
+    "default": {
+        "model_output_dir": "{{codebase_install}}",
+        "perturbed_model_output_dir": "{{codebase_install}}/perturb/{{experiment_name}}_member_id_{member_id}",
+        "experiment_name": "{{experiment_name}}",
+        "perturbed_experiment_name": "{{experiment_name}}_member_id_{member_id}",
+        "stats_file_name": "{{reference}}/reference/{{experiment_name}}_{member_id}.csv",
+        "tolerance_file_name": "{{reference}}/tolerance/{{experiment_name}}.csv",
+        "member_num": "[{member_num}]",
+        "member_type": "{{member_type}}",
+        "file_specification": [{
+            "NetCDF": { "format": "netcdf", "time_dim": null, "horizontal_dims": "ncells" }
+        }],
+        "savedir": "{{reference}}/plots"
+    },
+    "perturb": {
+        "perturb_amplitude": 1e-14,
+        "variable_names": ["ta", "clw"],
+        "copy_all_files": false,
+        "files": ["aes-new-gr_moderate-dt30s_atm_3d_ml_20080801T000000Z.nc"],
+        "model_input_dir": "{{codebase_install}}",
+        "perturbed_model_input_dir": "{{reference}}/perturb/{{experiment_name}}_member_id_{member_id}"
+    },
+    "stats": {
+        "ensemble": true
+    },
+    "check": {
+        "input_file_ref": "{{reference}}/reference/{{experiment_name}}_{{member_num[0] if member_num|length>1 else 1}}.csv",
+        "input_file_cur": "{{reference}}/reference/{{experiment_name}}_{{member_num[1] if member_num|length>1 else 2}}.csv",
+        "factor": 5
+    },
+    "run": {
+        "run_script_name": "run_all_schemes.sh",
+        "perturbed_run_script_name": "run_all_schemes_member_id_{member_id}.sh",
+        "run_dir": "{{codebase_install}}",
+        "perturbed_run_dir": "{{reference}}/perturb/{{experiment_name}}_member_id_{member_id}",
+        "lhs": [null, null],
+        "rhs_new": [null, null],
+        "rhs_old": [null, null],
+        "submit_command": "bash",
+        "parallel": false,
+        "dry": false
+    }
+}


### PR DESCRIPTION
1mom-microphysics granule runs all schemes inside the same rundir to save runtime to create the perturbed input-data.
Therefore create folder for each member, not only once for all members.

Pipeline to check: https://gitlab.dkrz.de/icon/icon-nwp/-/pipelines/55443

Corresponding MR: https://gitlab.dkrz.de/icon/icon-nwp/-/merge_requests/1251

New tolerances look reasonable:
`/scratch/mch/jenkins/icon/pool/data/ICON/buildbot_data/ref/7e230cb75b6a022f4e3e57e553274a3e3b8c9147/mch_kenda-ch1_small_tolerance.csv`
or 
`/scratch/mch/jenkins/icon/pool/data/ICON/buildbot_data/ref/21a8c3389ed04e04ed96fb2569800189079dbd3f/mch_ch_lowres_tolerance.csv`