### PR TITLE
Remove Account from sbatch submit_command

### DIFF
--- a/templates/ICON.jinja
+++ b/templates/ICON.jinja
@@ -78,7 +78,7 @@
             "lhs": ["pinit_seed", "pinit_amplitude"],
             "rhs_new": ["{seed}", "{{perturb_amplitude}}"],
             "rhs_old": [null, null],
-            "submit_command": "sbatch --wait --account=g110",
+            "submit_command": "sbatch --wait",
             "parallel": true,
             "dry": false
         }

--- a/util/click_util.py
+++ b/util/click_util.py
@@ -83,7 +83,7 @@ cli_help = {
     "stats_file_name": r"the name of the stats file. No absolute path here, it will "
     + r"always be created in the (perturbed) model_output_dir.",
     "member_num": r"number of ensemble members or a comma separated list of members "
-    + r"(e.g. \"1,3,14\")",
+    + r'(e.g. "1,3,14")',
     "member_type": r"precision of experiment (e.g. double or mixed). "
     + r"The type is part of the created member_id, which is equal to "
     + r"(member_type+'_'+str(member_num))",
@@ -94,7 +94,7 @@ cli_help = {
     "file_id": r"A unique identifier and file pattern FILE_PATTERN of the files "
     + r"containing the variables to be analysed and the file specification label "
     + r"FILE_TYPE. FILE_PATTERN may contain simple shell-style wildcards such as "
-    + r"\"*\" and will be expanded internally by glob. Put FILE_PATTERN in quotes to "
+    + r'"*" and will be expanded internally by glob. Put FILE_PATTERN in quotes to '
     + r"avoid early glob expansion by the calling shell.",
     "ensemble": r"For ensemble stats: the sub-directory where the ensemble outputs are",
     "file_specification": "Specify how different file types shall be read. This "


### PR DESCRIPTION
Setting the account for the `sbatch` in the `submit_command` explicitly to `g110` is not very helpful when running probtest as a user that is not part of g110 or running it on another system.  I think this parameter should not be required on any system and we can simply remove it.

The `submit_command` is only used in `run_ensemble`. Buildbot, however, uses `run_ensemble` only in the `dry` mode, i.e. no jobs are submitted. Thus `submit_command` is not used by Buildbot at all.