### PR TITLE
Run jobs parallel again

### DIFF
--- a/engine/run_ensemble.py
+++ b/engine/run_ensemble.py
@@ -109,13 +109,13 @@ def prepare_perturbed_run_script(
 
 
 def append_job(job, job_list, parallel):
-    with subprocess.Popen(job) as p:
-        if not parallel:
-            p.communicate()
-            time.sleep(5)
-            test_job_returncode(p)
-        else:
-            job_list.append(p)
+    p = subprocess.Popen(job)
+    if not parallel:
+        p.communicate()
+        time.sleep(5)
+        test_job_returncode(p)
+    else:
+        job_list.append(p)
 
 
 def finalize_jobs(job_list, dry, parallel):

--- a/engine/run_ensemble.py
+++ b/engine/run_ensemble.py
@@ -111,9 +111,12 @@ def prepare_perturbed_run_script(
 def append_job(job, job_list, parallel):
     p = subprocess.Popen(job)
     if not parallel:
-        p.communicate()
-        time.sleep(5)
-        test_job_returncode(p)
+        try:
+            time.sleep(5)
+            p.wait()
+            test_job_returncode(p)
+        finally:
+            p.kill()
     else:
         job_list.append(p)
 

--- a/engine/run_ensemble.py
+++ b/engine/run_ensemble.py
@@ -109,7 +109,7 @@ def prepare_perturbed_run_script(
 
 
 def append_job(job, job_list, parallel):
-    p = subprocess.Popen(job)
+    p = subprocess.Popen(job) # pylint: disable=consider-using-with
     if not parallel:
         try:
             time.sleep(5)

--- a/engine/run_ensemble.py
+++ b/engine/run_ensemble.py
@@ -109,7 +109,7 @@ def prepare_perturbed_run_script(
 
 
 def append_job(job, job_list, parallel):
-    p = subprocess.Popen(job) # pylint: disable=consider-using-with
+    p = subprocess.Popen(job)  # pylint: disable=consider-using-with
     if not parallel:
         try:
             time.sleep(5)


### PR DESCRIPTION
When running an ensemble, one of the changes in [Cleanup of requirements and increase code quality](https://github.com/MeteoSwiss/probtest/commit/45ef5918ab49256e3c0d64183c55d8e676a7d46a), made the jobs being run sequentially instead of parallel on the login nodes. This MR reverts the relevant change.