### PR TITLE
Add improved comparing when dealing with NAN values

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,7 +7,7 @@
 | Marek Jacob             | DWD                                                 |
 | Jonas Jucker            | C2SM                                                |
 | Annika Lauber           | C2SM                                                |
+| Christoph Müller        | MeteoSwiss                                          |
 | Giacomo Serafini        | MeteoSwiss                                          |
 | Mikael Stellio          | C2SM                                                |
 | Ben Weber               | MeteoSwiss                                          |
-| Christoph Müller        | MeteoSwiss                                          |

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,3 +10,4 @@
 | Giacomo Serafini        | MeteoSwiss                                          |
 | Mikael Stellio          | C2SM                                                |
 | Ben Weber               | MeteoSwiss                                          |
+| Christoph Müller        | MeteoSwiss                                          |

--- a/tests/engine/test_check.py
+++ b/tests/engine/test_check.py
@@ -5,6 +5,8 @@ of check CLI commands.
 
 import os
 
+import numpy as np
+import pandas as pd
 import pytest
 from click.testing import CliRunner
 
@@ -76,6 +78,60 @@ def test_check_cli_stats(stats_dataframes):
     )
 
     assert result.exit_code == 0
+
+
+def test_check_cli_stats_nan_mismatch_fails(tmp_dir):
+    """
+    A value present (non-NaN) in one stats file but missing (NaN) in the other is a
+    real difference that must fail, even with a generous tolerance. The two files are
+    otherwise identical (relative diff 0), so without the NaN guard this would pass.
+    Covers the non-FOF path of the appeared/disappeared check.
+    """
+    index = pd.MultiIndex.from_arrays(
+        [["NetCDF:*atm_3d*.nc"] * 2, ["var_1", "var_2"], [0, 0]],
+        names=["file_ID", "variable", "height"],
+    )
+    columns = pd.MultiIndex.from_product(
+        [range(2), ["max", "mean", "min"]], names=["time", "statistic"]
+    )
+    df1 = pd.DataFrame(np.ones((2, 6)), index=index, columns=columns)
+    df2 = df1.copy()
+    # one cell present in the reference but missing in the current file
+    df2.iloc[0, 0] = np.nan
+
+    tol = pd.DataFrame(
+        np.ones((2, 6)) * 1e3,
+        index=pd.Index(["var_1", "var_2"], name="variable"),
+        columns=columns,
+    )
+    tol = pd.concat(
+        [tol], keys=["NetCDF:*atm_3d*.nc"], names=["file_ID", "variable"]
+    )
+
+    df1_file = os.path.join(tmp_dir, "stats_nan1.csv")
+    df2_file = os.path.join(tmp_dir, "stats_nan2.csv")
+    tol_file = os.path.join(tmp_dir, "stats_nan_tol.csv")
+    df1.to_csv(df1_file)
+    df2.to_csv(df2_file)
+    tol.to_csv(tol_file)
+
+    result = CliRunner().invoke(
+        check,
+        [
+            "--reference-files",
+            df1_file,
+            "--current-files",
+            df2_file,
+            "--tolerance-files",
+            tol_file,
+            "--factor",
+            "1.0",
+            "--fof-types",
+            "",
+        ],
+    )
+
+    assert result.exit_code == 1
 
 
 def test_check_cli_fof(fof_datasets):

--- a/tests/engine/test_check.py
+++ b/tests/engine/test_check.py
@@ -103,9 +103,7 @@ def test_check_cli_stats_nan_mismatch_fails(tmp_dir):
         index=pd.Index(["var_1", "var_2"], name="variable"),
         columns=columns,
     )
-    tol = pd.concat(
-        [tol], keys=["NetCDF:*atm_3d*.nc"], names=["file_ID", "variable"]
-    )
+    tol = pd.concat([tol], keys=["NetCDF:*atm_3d*.nc"], names=["file_ID", "variable"])
 
     df1_file = os.path.join(tmp_dir, "stats_nan1.csv")
     df2_file = os.path.join(tmp_dir, "stats_nan2.csv")

--- a/tests/engine/test_check.py
+++ b/tests/engine/test_check.py
@@ -85,7 +85,6 @@ def test_check_cli_stats_nan_mismatch_fails(tmp_dir):
     A value present (non-NaN) in one stats file but missing (NaN) in the other is a
     real difference that must fail, even with a generous tolerance. The two files are
     otherwise identical (relative diff 0), so without the NaN guard this would pass.
-    Covers the non-FOF path of the appeared/disappeared check.
     """
     index = pd.MultiIndex.from_arrays(
         [["NetCDF:*atm_3d*.nc"] * 2, ["var_1", "var_2"], [0, 0]],

--- a/tests/util/test_dataframe_ops.py
+++ b/tests/util/test_dataframe_ops.py
@@ -14,6 +14,7 @@ import xarray as xr
 
 from util.constants import CHECK_THRESHOLD
 from util.dataframe_ops import (
+    check_file_with_tolerances,
     check_intersection,
     check_multiple_solutions_from_dict,
     check_variable,
@@ -541,6 +542,49 @@ def test_check_intersection_pass(ds_intersection):
     assert skip_test == 0
     assert df_ref.equals(df1)
     assert df_cur.equals(df2)
+
+
+@pytest.mark.parametrize(
+    "ref_val, cur_val, expected_pass",
+    [
+        # one side NaN, the other a real value -> appeared/disappeared -> must FAIL,
+        # even though the tolerance is huge (the relative diff itself is NaN).
+        (np.nan, 1.0, False),
+        (1.0, np.nan, False),
+        # both NaN -> both missing -> equal -> must PASS.
+        (np.nan, np.nan, True),
+        # both real and identical -> within any tolerance -> must PASS.
+        (1.0, 1.0, True),
+    ],
+)
+@patch("util.dataframe_ops.parse_check")
+def test_check_file_nan_vs_non_nan(mock_parse_check, ref_val, cur_val, expected_pass):
+    """
+    The nan-vs-non-nan guard: a cell present in one file but missing in the other is
+    forced to inf so it fails regardless of tolerance, while both-NaN stays equal.
+    Drives check_file_with_tolerances directly with a generous tolerance so only the
+    NaN handling -- not the magnitude -- decides the outcome.
+    """
+    index = pd.MultiIndex.from_tuples(
+        [("f", "var_1", 0), ("f", "var_2", 0)],
+        names=["file_ID", "variable", "height"],
+    )
+    df_ref = pd.DataFrame({0: [ref_val, 1.0]}, index=index)
+    df_cur = pd.DataFrame({0: [cur_val, 1.0]}, index=index)
+    df_tol = pd.DataFrame(
+        {0: [1e3, 1e3]},
+        index=pd.MultiIndex.from_tuples(
+            [("f", "var_1"), ("f", "var_2")], names=["file_ID", "variable"]
+        ),
+    )
+    mock_parse_check.return_value = (df_tol, df_ref, df_cur)
+
+    ref = WithPath("ref.csv", file_type=FileType.STATS)
+    cur = WithPath("cur.csv", file_type=FileType.STATS)
+
+    out, _, _ = check_file_with_tolerances("tol.csv", ref, cur, 1.0)
+
+    assert out is expected_pass
 
 
 def test_check_variable():

--- a/util/dataframe_ops.py
+++ b/util/dataframe_ops.py
@@ -389,6 +389,16 @@ def check_file_with_tolerances(
 
     # compute relative difference
     diff_df = compute_rel_diff_dataframe(df_ref, df_cur)
+
+    # A value present (non-NaN) in one file but missing (NaN) in the other is a real
+    # difference -- a field or observation appeared or disappeared. The relative diff
+    # is NaN there and check_variable would treat NaN as within tolerance, silently
+    # passing it; force those cells to fail. Both-NaN stays NaN (and passes), since
+    # both being missing means they are equal. This runs before the STATS reduction
+    # below so the mask aligns with df_ref/df_cur, and because inf survives max().
+    only_one_nan = df_ref.isna() ^ df_cur.isna()
+    diff_df = diff_df.mask(only_one_nan, np.inf)
+
     # if stats, take maximum over height
     if input_file_ref.file_type == FileType.STATS:
         diff_df = diff_df.groupby(["file_ID", "variable"]).max()


### PR DESCRIPTION
A value present (non-NaN) in one file but missing (NaN) in the other is a real difference -- a field or observation appeared or disappeared. The relative diff is NaN there and check_variable would treat NaN as within tolerance, silently passing it; force those cells to fail. Both-NaN stays NaN (and passes), since both being missing means they are equal.