### PR TITLE
Compute and output normalized error above tolerance

### DIFF
--- a/engine/check.py
+++ b/engine/check.py
@@ -88,10 +88,19 @@ def check(
             logger.info("RESULT: check FAILED for %s", current_file)
             log_dataframe(logger, "Differences", err, verbose=verbose)
             log_dataframe(logger, "\nTolerances", tol, verbose=verbose)
+
+            err_rel_tol = compute_division(err, tol)
+            err_above_tol = (err_rel_tol - 1.).clip(lower=0.)
             log_dataframe(
                 logger,
                 "\nError relative to tolerance",
-                compute_division(err, tol),
+                err_rel_tol,
+                verbose=verbose,
+            )
+            log_dataframe(
+                logger,
+                "\nNormalized error above tolerance",
+                err_above_tol,
                 verbose=verbose,
             )
             all_out = False


### PR DESCRIPTION
This PR adds the computation of a fourth metric for the output of _check.py_. Instead of only showing the "Error relative to tolerance":
```
err_rel_tol = err / tol
```
We also show the "Normalized error above tolerance":
```
err_above_tol = (err - tol) / tol = err / tol - 1
```
This let's user see how much above the tolerance the checked variables are, in a normalized fashion, such that errors for different variables can be compared. This is especially useful when `err_rel_tol` is very close to `1`, since the precision of the output only shows 2 decimal digits. With this new output you can see how much above the tolerance the values are even if they are only slightly above (i.e. `err_rel_tol ~ 1`).

Note that values that do not exceed the tolerance are clipped to `0`, this allows for spotting errors quicker.